### PR TITLE
device: lenovo: sdm710: We don't have a ramdisk in boot

### DIFF
--- a/device/lenovo/sdm710.py
+++ b/device/lenovo/sdm710.py
@@ -3,4 +3,4 @@ from device.qcom.sdm845 import QcomSDM845Device
 class LenovoSDM710Device(QcomSDM845Device):
 	TARGET_ARCH = "arm64"
 	TARGET_KERNEL_SOURCE = "kernel/lenovo/sdm710"
-	BOARD_BUILD_SYSTEM_ROOT_IMAGE = False
+	BOARD_BUILD_SYSTEM_ROOT_IMAGE = True


### PR DESCRIPTION
Tested on latest PE device kernel source (kunlun/jd2019)